### PR TITLE
ci: rm asdf action no longer needed

### DIFF
--- a/.github/workflows/awesome-linter.yml
+++ b/.github/workflows/awesome-linter.yml
@@ -23,7 +23,5 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: asdf_install
-        uses: asdf-vm/actions/install@v1
       - name: "linting: README.md"
-        run: npx -y awesome-lint README.md
+        run: npx -y awesome-lint


### PR DESCRIPTION
Sorry, I should have checked updates in the awesome linter workflow.
Since GitHub Actions now uses a more up to date version of Node.js, a step (which required a `.tools-versions` file is no longer required.
With this, the linter should work properly (I just tested it in <https://github.com/mcanouil/awesome-quarto>).